### PR TITLE
Consumergoup additions

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -33,7 +33,10 @@ type ConsumergroupInstance struct {
 	ID string
 }
 
+// ConsumergroupList implements the sortable interface on top of a consumer group list
 type ConsumergroupList []*Consumergroup
+
+// ConsumergroupInstanceList implements the sortable interface on top of a consumer instance list
 type ConsumergroupInstanceList []*ConsumergroupInstance
 
 type Registration struct {
@@ -178,6 +181,10 @@ func (cg *Consumergroup) PartitionOwner(topic string, partition int32) (*Consume
 	}
 }
 
+// WatchPartitionOwner retrieves what instance is currently owning the partition, and sets a
+// Zookeeper watch to be notified of changes. If the partition currently does not have an owner,
+// the function returns nil for every return value. In this case is should be safe to claim
+// the partition for an instance.
 func (cg *Consumergroup) WatchPartitionOwner(topic string, partition int32) (*ConsumergroupInstance, <-chan zk.Event, error) {
 	node := fmt.Sprintf("%s/consumers/%s/owners/%s/%d", cg.kz.conf.Chroot, cg.Name, topic, partition)
 	instanceID, _, changed, err := cg.kz.conn.GetW(node)

--- a/kazoo.go
+++ b/kazoo.go
@@ -159,6 +159,7 @@ func (kz *Kazoo) Controller() (int32, error) {
 	return controllerNode.BrokerID, nil
 }
 
+// Close closes the connection with the Zookeeper cluster
 func (kz *Kazoo) Close() error {
 	kz.conn.Close()
 	return nil

--- a/kazoo.go
+++ b/kazoo.go
@@ -27,6 +27,19 @@ func ParseConnectionString(zookeeper string) (nodes []string, chroot string) {
 	return
 }
 
+// BuildConnectionString builds a Zookeeper connection string for a list of nodes.
+// Returns a string like "zk1:2181,zk2:2181,zk3:2181"
+func BuildConnectionString(nodes []string) string {
+	return strings.Join(nodes, ",")
+}
+
+// ConnectionStringWithChroot builds a Zookeeper connection string for a list
+// of nodes and a chroot. The chroot should start with "/".
+// Returns a string like "zk1:2181,zk2:2181,zk3:2181/chroot"
+func BuildConnectionStringWithChroot(nodes []string, chroot string) string {
+	return fmt.Sprintf("%s%s", strings.Join(nodes, ","), chroot)
+}
+
 // Kazoo interacts with the Kafka metadata in Zookeeper
 type Kazoo struct {
 	conn *zk.Conn

--- a/kazoo_test.go
+++ b/kazoo_test.go
@@ -4,6 +4,18 @@ import (
 	"testing"
 )
 
+func TestBuildConnectionString(t *testing.T) {
+	nodes := []string{"zk1:2181", "zk2:2181", "zk3:2181"}
+
+	if str := BuildConnectionString(nodes); str != "zk1:2181,zk2:2181,zk3:2181" {
+		t.Errorf("The connection string was not built correctly: %s", str)
+	}
+
+	if str := BuildConnectionStringWithChroot(nodes, "/chroot"); str != "zk1:2181,zk2:2181,zk3:2181/chroot" {
+		t.Errorf("The connection string was not built correctly: %s", str)
+	}
+}
+
 func TestParseConnectionString(t *testing.T) {
 	var (
 		nodes  []string

--- a/topic_metadata.go
+++ b/topic_metadata.go
@@ -147,7 +147,11 @@ func (p *Partition) Key() string {
 }
 
 func (p *Partition) PreferredReplica() int32 {
-	return p.Replicas[0]
+	if len(p.Replicas) > 0 {
+		return p.Replicas[0]
+	} else {
+		return -1
+	}
 }
 
 // Leader returns the broker ID of the broker that is currently the leader for the partition.

--- a/topic_metadata.go
+++ b/topic_metadata.go
@@ -236,7 +236,7 @@ func (pl PartitionList) Len() int {
 }
 
 func (pl PartitionList) Less(i, j int) bool {
-	return pl[i].ID < pl[j].ID
+	return pl[i].topic.Name < pl[j].topic.Name || (pl[i].topic.Name == pl[j].topic.Name && pl[i].ID < pl[j].ID)
 }
 
 func (pl PartitionList) Swap(i, j int) {

--- a/topic_metadata.go
+++ b/topic_metadata.go
@@ -43,7 +43,11 @@ func (kz *Kazoo) Topic(topic string) *Topic {
 	return &Topic{Name: topic, kz: kz}
 }
 
-// Partitions returns a map of all partitions for the topic.
+func (t *Topic) Exists() (bool, error) {
+	return t.kz.exists(fmt.Sprintf("%s/brokers/topics/%s", t.kz.conf.Chroot, t.Name))
+}
+
+// Partitions returns a list of all partitions for the topic.
 func (t *Topic) Partitions() (PartitionList, error) {
 	node := fmt.Sprintf("%s/brokers/topics/%s", t.kz.conf.Chroot, t.Name)
 	value, _, err := t.kz.conn.Get(node)
@@ -98,6 +102,18 @@ func (t *Topic) Config() (map[string]string, error) {
 	}
 
 	return topicConfig.ConfigMap, nil
+}
+
+func (p *Partition) Topic() *Topic {
+	return p.topic
+}
+
+func (p *Partition) Key() string {
+	return fmt.Sprintf("%s/%d", p.topic.Name, p.ID)
+}
+
+func (p *Partition) PreferredReplica() int32 {
+	return p.Replicas[0]
 }
 
 // Leader returns the broker ID of the broker that is currently the leader for the partition.

--- a/topic_metadata_test.go
+++ b/topic_metadata_test.go
@@ -1,0 +1,67 @@
+package kazoo
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestPartition(t *testing.T) {
+	topic := &Topic{Name: "test"}
+	partition := topic.Partition(1, []int32{1, 2, 3})
+
+	if key := partition.Key(); key != "test/1" {
+		t.Error("Unexpected partition key", key)
+	}
+
+	if partition.Topic() != topic {
+		t.Error("Expected Topic() to return the topic the partition was created from.")
+	}
+
+	if pr := partition.PreferredReplica(); pr != 1 {
+		t.Error("Expected 1 to be the preferred replica, but found", pr)
+	}
+
+	partitionWithoutReplicas := topic.Partition(1, nil)
+	if pr := partitionWithoutReplicas.PreferredReplica(); pr != -1 {
+		t.Error("Expected -1 to be returned if the partition does not have replicas, but found", pr)
+	}
+}
+
+func TestTopicList(t *testing.T) {
+	topics := TopicList{
+		&Topic{Name: "foo"},
+		&Topic{Name: "bar"},
+		&Topic{Name: "baz"},
+	}
+
+	sort.Sort(topics)
+
+	if topics[0].Name != "bar" || topics[1].Name != "baz" || topics[2].Name != "foo" {
+		t.Error("Unexpected order after sorting topic list", topics)
+	}
+
+	topic := topics.Find("foo")
+	if topic != topics[2] {
+		t.Error("Should have found foo topic from the list")
+	}
+}
+
+func TestPartitionList(t *testing.T) {
+	var (
+		topic1 = &Topic{Name: "1"}
+		topic2 = &Topic{Name: "2"}
+	)
+
+	var (
+		partition21 = topic2.Partition(1, nil)
+		partition12 = topic1.Partition(2, nil)
+		partition11 = topic1.Partition(1, nil)
+	)
+
+	partitions := PartitionList{partition21, partition12, partition11}
+	sort.Sort(partitions)
+
+	if partitions[0] != partition11 || partitions[1] != partition12 || partitions[2] != partition21 {
+		t.Error("Unexpected order after sorting topic list", partitions)
+	}
+}


### PR DESCRIPTION
This adds a bunch of methods to improve the kafka high level consumer.

- Helper methods on `Topic` and `Partition` types.
- `WatchPartitionOwner` to watch a partition claim.
- `WatchTopics` & `WatchPartitions` to return the list and watch Zookeeper for changes.