### PR TITLE
Have ResetOffsets delete the partitionNode's current version

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -417,8 +417,11 @@ func (cg *Consumergroup) ResetOffsets() error {
 
 		for _, partition := range partitions {
 			partitionNode := fmt.Sprintf("%s/consumers/%s/offsets/%s/%s", cg.kz.conf.Chroot, cg.Name, topic, partition)
-			if err := cg.kz.conn.Delete(partitionNode, 0); err != nil {
-				return err
+			exists, stat, err := cg.kz.conn.Exists(partitionNode)
+			if exists {
+				if err = cg.kz.conn.Delete(partitionNode, stat.Version); err != nil {
+					return err
+				}
 			}
 		}
 


### PR DESCRIPTION
This is better than doing a delete of version 0. I believe that this change makes ResetOffsets actually do what was intended.