### PR TITLE
Typo fix 

### DIFF
--- a/kazoo.go
+++ b/kazoo.go
@@ -87,7 +87,7 @@ func NewKazooFromConnectionString(connectionString string, conf *Config) (*Kazoo
 }
 
 // Brokers returns a map of all the brokers that make part of the
-// Kafka cluster that is regeistered in Zookeeper.
+// Kafka cluster that is registered in Zookeeper.
 func (kz *Kazoo) Brokers() (map[int32]string, error) {
 	root := fmt.Sprintf("%s/brokers/ids", kz.conf.Chroot)
 	children, _, err := kz.conn.Children(root)


### PR DESCRIPTION
Fix the spelling of "registered" in kazoo.go