### PR TITLE
Handle race when many consumers call ResetOffsets

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -420,13 +420,17 @@ func (cg *Consumergroup) ResetOffsets() error {
 			exists, stat, err := cg.kz.conn.Exists(partitionNode)
 			if exists {
 				if err = cg.kz.conn.Delete(partitionNode, stat.Version); err != nil {
-					return err
+					if err != zk.ErrNoNode {
+						return err
+					}
 				}
 			}
 		}
 
 		if err := cg.kz.conn.Delete(topicNode, stat.Version); err != nil {
-			return err
+			if err != zk.ErrNoNode {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
There can be a race condition when many consumers in a group are trying
to reset offsets. This happens in the gap between checking if a zk node
exists and deleting the node.

A way to handle this is to check if the error returned by Delete is
zk.ErrNoNode and ignoring it.