### PR TITLE
Add WatchRegistration function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-- "1.5"
-- "1.6"
+- 1.8
+- 1.9
 
 env:
   global:

--- a/consumergroup.go
+++ b/consumergroup.go
@@ -219,6 +219,22 @@ func (cgi *ConsumergroupInstance) Registration() (*Registration, error) {
 	return reg, nil
 }
 
+// WatchRegistered returns current registration of the consumer group instance,
+// and a channel that will be closed as soon the registration changes.
+func (cgi *ConsumergroupInstance) WatchRegistration() (*Registration, <-chan zk.Event, error) {
+	node := fmt.Sprintf("%s/consumers/%s/ids/%s", cgi.cg.kz.conf.Chroot, cgi.cg.Name, cgi.ID)
+	val, _, c, err := cgi.cg.kz.conn.GetW(node)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	reg := &Registration{}
+	if err := json.Unmarshal(val, reg); err != nil {
+		return nil, nil, err
+	}
+	return reg, c, nil
+}
+
 // RegisterSubscription registers the consumer instance in Zookeeper, with its subscription.
 func (cgi *ConsumergroupInstance) RegisterWithSubscription(subscriptionJSON []byte) error {
 	if exists, err := cgi.Registered(); err != nil {
@@ -234,11 +250,38 @@ func (cgi *ConsumergroupInstance) RegisterWithSubscription(subscriptionJSON []by
 
 // Register registers the consumergroup instance in Zookeeper.
 func (cgi *ConsumergroupInstance) Register(topics []string) error {
+	subscriptionJSON, err := cgi.marshalSubscription(topics)
+	if err != nil {
+		return err
+	}
+
+	return cgi.RegisterWithSubscription(subscriptionJSON)
+}
+
+// UpdateRegistration updates a consumer group member registration. If the
+// consumer group member has not been registered yet, then an error is returned.
+func (cgi *ConsumergroupInstance) UpdateRegistration(topics []string) error {
+	subscriptionJSON, err := cgi.marshalSubscription(topics)
+	if err != nil {
+		return err
+	}
+
+	node := fmt.Sprintf("%s/consumers/%s/ids/%s", cgi.cg.kz.conf.Chroot, cgi.cg.Name, cgi.ID)
+	_, stat, err := cgi.cg.kz.conn.Get(node)
+	if err != nil {
+		return err
+	}
+
+	_, err = cgi.cg.kz.conn.Set(node, subscriptionJSON, stat.Version)
+	return err
+}
+
+// Register registers the consumergroup instance in Zookeeper.
+func (cgi *ConsumergroupInstance) marshalSubscription(topics []string) ([]byte, error) {
 	subscription := make(map[string]int)
 	for _, topic := range topics {
 		subscription[topic] = 1
 	}
-
 	data, err := json.Marshal(&Registration{
 		Pattern:      RegPatternStatic,
 		Subscription: subscription,
@@ -246,10 +289,9 @@ func (cgi *ConsumergroupInstance) Register(topics []string) error {
 		Version:      RegDefaultVersion,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	return cgi.RegisterWithSubscription(data)
+	return data, nil
 }
 
 // Deregister removes the registration of the instance from zookeeper.


### PR DESCRIPTION
The library only provided `WatchInstance` function that returned a watch of child type. But child type watches are triggered by group member subscription updates, so `WatchRegistration` function was introduced to allow watching member subscription updates.

Besides:
* There was no way to update an existing subscription so clients had to make a `Deregister`/`Register` sequence, that resulted in extra watch trigger. So `UpdateRegistration` function was added to rectify this deficiency.  
* A redundant call of `Exists` was removed in a couple of methods. It seems better to just make whatever call we need and check for `ErrNoNode` error instead.