### PR TITLE
Report registration errors consistently

### DIFF
--- a/functional_consumergroup_test.go
+++ b/functional_consumergroup_test.go
@@ -92,7 +92,7 @@ func TestConsumergroupInstances(t *testing.T) {
 
 	instance1 := cg.NewInstance()
 	// Make sure that the instance is unregistered.
-	if reg, err := instance1.Registration(); err != zk.ErrNoNode || reg != nil {
+	if reg, err := instance1.Registration(); err != ErrInstanceNotRegistered || reg != nil {
 		t.Errorf("Expected no registration: reg=%v, err=(%v)", reg, err)
 	}
 
@@ -237,6 +237,14 @@ func TestConsumergroupWatchInstances(t *testing.T) {
 	}
 
 	instance := cg.NewInstance()
+
+	// Make sure a proper error is returned when an unregistered instance is
+	// updated.
+	err = instance.UpdateRegistration([]string{"foo"})
+	if err != ErrInstanceNotRegistered {
+		t.Fatal("Expected ErrInstanceNotRegistered")
+	}
+
 	if err := instance.Register([]string{"topic"}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Registration related functions have been returning inconsistently either `kazoo` specific errors `ErrInstanceAlreadyRegistered` and  `ErrInstanceNotRegistered`, or  `zookeeper-go` errors `zk.ErrNoNode` and `zk.ErrNodeExists`.

Unfortunately it is impossible to fix this issue without breaking backwards compatibility with users that expect either of those errors. Nonetheless I suggest all the registration related function to return `kazoo` specific errors consistently.

Note that some of the fixed cases almost impossible to reproduce, because they address subtle race that can occur between Get and subsequent Set. 